### PR TITLE
Fix joinServer for TF2

### DIFF
--- a/js/inject.js
+++ b/js/inject.js
@@ -343,7 +343,7 @@ var faceitHelper = {
 	},
     joinServer: function(serverIP) {
 		setTimeout(function() {
-			var StartParameter = "steam://rungame/730/76561202255233023/+connect%20" + serverIP;
+			var StartParameter = "steam://connect/" + serverIP;
 			faceitHelper.debug.log("Triggering following address:" + StartParameter);
 			window.location = StartParameter;
 		}, 3000);


### PR DESCRIPTION
steam://connect/<IP> launches the appropriate game and connects to the server.
https://developer.valvesoftware.com/wiki/Steam_browser_protocol